### PR TITLE
Fixed an infinite loop from a missing 'i++'

### DIFF
--- a/BZGFormViewController/BZGFormViewController.m
+++ b/BZGFormViewController/BZGFormViewController.m
@@ -133,8 +133,7 @@
     NSUInteger cellIndex = [self.formFieldCells indexOfObject:fieldCell];
     if (cellIndex == NSNotFound) return nil;
 
-    NSUInteger i = cellIndex + 1;
-    while (i < self.formFieldCells.count) {
+    for (NSUInteger i = cellIndex + 1; i < self.formFieldCells.count; ++i) {
         UITableViewCell *cell = self.formFieldCells[i];
         if ([cell isKindOfClass:[BZGFormFieldCell class]]) {
             return (BZGFormFieldCell *)cell;


### PR DESCRIPTION
To trigger the infinite loop, I filled out the fields in the example app with bogus data, then went back to the middle field, and pressed the return key.

This project looks great by the way. Thanks for releasing it!
