### PR TITLE
[Podspec] update to 2.4.4 and point to ReactiveCocoa 2.0

### DIFF
--- a/BZGFormViewController.podspec
+++ b/BZGFormViewController.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |s|
   s.name     = 'BZGFormViewController'
-  s.version  = '2.4.3'
+  s.version  = '2.4.4'
   s.license  = 'MIT'
   s.summary  = 'A library for creating dynamic forms.'
   s.homepage = 'https://github.com/benzguo/BZGFormViewController'
@@ -9,7 +9,7 @@ Pod::Spec.new do |s|
     :git => 'https://github.com/benzguo/BZGFormViewController.git',
     :tag => "v#{s.version}"
   }
-  s.dependency 'ReactiveCocoa', '~>2.2.4'
+  s.dependency 'ReactiveCocoa', '~>2.0'
   s.dependency 'libextobjc', '~>0.4'
   s.dependency 'libPhoneNumber-iOS'
   s.requires_arc = true


### PR DESCRIPTION
Accommodates minor version and patch updates, but ensures API compatibility.

Fixes #41 
