### PR TITLE
Improvement: Respect the original view content insets

### DIFF
--- a/BZGFormViewController/BZGFormViewController.m
+++ b/BZGFormViewController/BZGFormViewController.m
@@ -24,7 +24,10 @@
 
 @end
 
-@implementation BZGFormViewController
+@implementation BZGFormViewController {
+    @protected
+    UIEdgeInsets _preKeyboardTableViewInsets;
+}
 
 - (id)init
 {
@@ -349,13 +352,17 @@
 {
     CGSize keyboardSize = [[[notification userInfo] objectForKey:UIKeyboardFrameBeginUserInfoKey] CGRectValue].size;
 
-    UIEdgeInsets contentInsets;
+    // Save the original contentInset so that it can be reset when the keyboard hides
+    _preKeyboardTableViewInsets = self.tableView.contentInset;
+
+    // Base the new inset off of the original
+    UIEdgeInsets contentInsets = _preKeyboardTableViewInsets;
 
     if ((floor(NSFoundationVersionNumber) > NSFoundationVersionNumber_iOS_7_1)
         || UIInterfaceOrientationIsPortrait([[UIApplication sharedApplication] statusBarOrientation])) {
-        contentInsets = UIEdgeInsetsMake(0.0, 0.0, (keyboardSize.height), 0.0);
+        contentInsets.bottom += keyboardSize.height;
     } else {
-        contentInsets = UIEdgeInsetsMake(0.0, 0.0, (keyboardSize.width), 0.0);
+        contentInsets.bottom += keyboardSize.width;
     }
 
     self.tableView.contentInset = contentInsets;
@@ -367,8 +374,11 @@
 {
     NSNumber *rate = notification.userInfo[UIKeyboardAnimationDurationUserInfoKey];
     [UIView animateWithDuration:rate.floatValue animations:^{
-        self.tableView.contentInset = UIEdgeInsetsZero;
-        self.tableView.scrollIndicatorInsets = UIEdgeInsetsZero;
+        self.tableView.contentInset = _preKeyboardTableViewInsets;
+        self.tableView.scrollIndicatorInsets = _preKeyboardTableViewInsets;
+        
+        // Reset: These insets should only exist for the lifetime of the visible keyboard
+        _preKeyboardTableViewInsets = UIEdgeInsetsZero;
     }];
 }
 

--- a/BZGFormViewControllerTests/BZGFormViewControllerSpecs.m
+++ b/BZGFormViewControllerTests/BZGFormViewControllerSpecs.m
@@ -363,4 +363,128 @@ describe(@"setShowsValidationCell", ^{
     });
 });
 
+describe(@"Keyboard notifications", ^{
+    describe(@"tableView.contentInset", ^{
+        __block UIEdgeInsets existingInsets;
+        __block UIEdgeInsets expectedInsets;
+        __block UIEdgeInsets insetsWithKeyboard;
+        __block CGRect keyboardRect;
+        __block CGSize keyboardSize;
+        __block NSDictionary *notificationUserInfo;
+        
+        before(^{
+            existingInsets       = UIEdgeInsetsMake(1.f, 1.f, 1.f, 1.f);
+            keyboardSize         = CGSizeMake(320.f, 270.f);
+            keyboardRect         = CGRectMake(0.f, 0.f, keyboardSize.width, keyboardSize.height);
+            notificationUserInfo = @{
+                                     UIKeyboardFrameBeginUserInfoKey        : [NSValue valueWithCGRect:keyboardRect],
+                                     UIKeyboardAnimationDurationUserInfoKey : [NSNumber numberWithInt:0]
+                                     };
+            insetsWithKeyboard = UIEdgeInsetsMake(existingInsets.top,
+                                                  existingInsets.left,
+                                                  existingInsets.bottom + keyboardSize.height,
+                                                  existingInsets.right);
+        });
+        
+        context(@"UIKeyboardWillShowNotification", ^{
+            before(^{
+                expectedInsets = insetsWithKeyboard;
+
+                formViewController.tableView.contentInset = existingInsets;
+                
+                [[NSNotificationCenter defaultCenter] postNotificationName:UIKeyboardWillShowNotification
+                                                                    object:nil
+                                                                  userInfo:notificationUserInfo];
+            });
+            
+            it(@"should maintain the current insets, adding the height of the keyboard", ^{
+                expect(formViewController.tableView.contentInset).to.equal(expectedInsets);
+            });
+        });
+        
+        context(@"UIKeyboardWillHideNotification", ^{
+            before(^{
+                expectedInsets = existingInsets;
+                
+                formViewController.tableView.contentInset = existingInsets;
+                
+                // Trigger the show (this sets up the with-keyboard-insets
+                [[NSNotificationCenter defaultCenter] postNotificationName:UIKeyboardWillShowNotification
+                                                                    object:nil
+                                                                  userInfo:notificationUserInfo];
+                
+                // "Hide" the keyboard
+                [[NSNotificationCenter defaultCenter] postNotificationName:UIKeyboardWillHideNotification
+                                                                    object:nil
+                                                                  userInfo:notificationUserInfo];
+            });
+            
+            it(@"should set the insets back to their original value", ^{
+                expect(formViewController.tableView.contentInset).to.equal(expectedInsets);
+            });
+        });
+    });
+    
+    describe(@"tableView.scrollIndicatorInsets", ^{
+        __block UIEdgeInsets existingInsets;
+        __block UIEdgeInsets expectedInsets;
+        __block UIEdgeInsets insetsWithKeyboard;
+        __block CGRect keyboardRect;
+        __block CGSize keyboardSize;
+        __block NSDictionary *notificationUserInfo;
+        
+        before(^{
+            existingInsets       = UIEdgeInsetsMake(1.f, 1.f, 1.f, 1.f);
+            keyboardSize         = CGSizeMake(320.f, 270.f);
+            keyboardRect         = CGRectMake(0.f, 0.f, keyboardSize.width, keyboardSize.height);
+            notificationUserInfo = @{
+                                     UIKeyboardFrameBeginUserInfoKey        : [NSValue valueWithCGRect:keyboardRect],
+                                     UIKeyboardAnimationDurationUserInfoKey : [NSNumber numberWithInt:0]
+                                     };
+            insetsWithKeyboard = UIEdgeInsetsMake(existingInsets.top,
+                                                  existingInsets.left,
+                                                  existingInsets.bottom + keyboardSize.height,
+                                                  existingInsets.right);
+        });
+        
+        context(@"UIKeyboardWillShowNotification", ^{
+            before(^{
+                expectedInsets = insetsWithKeyboard;
+                
+                formViewController.tableView.contentInset = existingInsets;
+                
+                [[NSNotificationCenter defaultCenter] postNotificationName:UIKeyboardWillShowNotification
+                                                                    object:nil
+                                                                  userInfo:notificationUserInfo];
+            });
+            
+            it(@"should maintain the current insets, adding the height of the keyboard", ^{
+                expect(formViewController.tableView.scrollIndicatorInsets).to.equal(expectedInsets);
+            });
+        });
+        
+        context(@"UIKeyboardWillHideNotification", ^{
+            before(^{
+                expectedInsets = existingInsets;
+                
+                formViewController.tableView.contentInset = existingInsets;
+                
+                // Trigger the show (this sets up the with-keyboard-insets
+                [[NSNotificationCenter defaultCenter] postNotificationName:UIKeyboardWillShowNotification
+                                                                    object:nil
+                                                                  userInfo:notificationUserInfo];
+                
+                // "Hide" the keyboard
+                [[NSNotificationCenter defaultCenter] postNotificationName:UIKeyboardWillHideNotification
+                                                                    object:nil
+                                                                  userInfo:notificationUserInfo];
+            });
+            
+            it(@"should set the insets back to their original value", ^{
+                expect(formViewController.tableView.scrollIndicatorInsets).to.equal(expectedInsets);
+            });
+        });
+    });
+});
+
 SpecEnd


### PR DESCRIPTION
This addresses an issue with the keyboard display/hide that interfered
with layouts that have existing content insets.

For example in a layout that is presented by a navigation controller
with `automaticallyAdjustsScrollViewInsets` enabled (the default), the
view is automatically given `contentInset` of `-64` at the `top`.

This update maintains that `-64` instead of resetting to zero when
dismissing the keyboard.